### PR TITLE
Add a button for "View Mobile Reports"

### DIFF
--- a/pmpro-reports-dashboard.php
+++ b/pmpro-reports-dashboard.php
@@ -99,6 +99,31 @@ function pmprordb_redirect_canonical_callback( $redirect_url, $requested_url ) {
 add_filter( 'redirect_canonical', 'pmprordb_redirect_canonical_callback', 100, 2 );
 
 /**
+ * Add links to the reports page in PMPro. /// move to page load rather on admin init.
+ */
+function pmprordb_add_links_report_page() {
+
+	// Only load on the reports main page.
+	if ( ! isset( $_REQUEST['page'] ) &&  $_REQUEST['page'] != 'pmpro-reports' ) {
+		return;
+	}
+
+	// We're viewing an individual report page, let's not show the link.
+	if ( isset( $_REQUEST['report'] ) && $_REQUEST['page'] == 'pmpro-reports' ) {
+		return;
+	}
+
+	?>
+	<script>
+		jQuery(document).ready(function() {
+			jQuery('.memberships_page_pmpro-reports h1').append(' <a id="pmprordb-view-mobile" class="page-title-action" href="/pmpro-reports-dashboard" target="_blank"><?php echo esc_html__( 'View Mobile Reports', 'pmpro-reports-dashboard' ); ?></a>');
+		});
+	</script>
+	<?php
+}
+add_action( 'admin_head', 'pmprordb_add_links_report_page' );
+
+/**
  * Add links to the plugin action links
  *
  * @param $links (array) - The existing link array


### PR DESCRIPTION
* Added functionality to "View Mobile Reports" button in the header of the reports dashboard screen.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-reports-dashboard/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-reports-dashboard/pulls/) for the same update/change?
